### PR TITLE
fix: xfail sklearn's check_regressors_int

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ warn_unreachable = true
 
 [tool.pytest.ini_options]  # https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
 addopts = "--color=yes --doctest-modules --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
-filterwarnings = ["error", "ignore::DeprecationWarning"]
+filterwarnings = ["error", "ignore::DeprecationWarning", "ignore::sklearn.exceptions.SkipTestWarning"]
 testpaths = ["src", "tests"]
 xfail_strict = true
 


### PR DESCRIPTION
On the one hand: scikit-learn's `check_regressors_int` expects the output predictions to be the same when fitting on an integer dtype target compared to fitting on an integer-valued float dtype target.

On the other hand: this package ensures that the dtype of `predict` matches the dtype of the target `y` that the estimator was fitted on. This is useful when for example the target is a datetime or a timedelta dtype.

These two requirements are incompatible with each other, and therefore we mark sklearn's `check_regressors_int` as expected to fail in this PR.